### PR TITLE
Removed HTML body default margin

### DIFF
--- a/src/PlayerScripts.js
+++ b/src/PlayerScripts.js
@@ -62,6 +62,9 @@ export const MAIN_SCRIPT = (
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1">
     <style>
+      body {
+        margin: 0;
+      }
       .container {
         position: relative;
         width: 100%;


### PR DESCRIPTION
I just added `body { margin: 0; }` to remove the HTML body default margin of 8px.